### PR TITLE
Fix directory of Python package (installed by pip)

### DIFF
--- a/src/fhiry/parallel.py
+++ b/src/fhiry/parallel.py
@@ -1,4 +1,4 @@
-from src.fhiry import Fhiry, Fhirndjson
+from fhiry import Fhiry, Fhirndjson
 import os
 import multiprocessing as mp
 import pandas as pd

--- a/src/fhiry/parallel.py
+++ b/src/fhiry/parallel.py
@@ -1,4 +1,4 @@
-from fhiry import Fhiry, Fhirndjson
+from . import Fhiry, Fhirndjson
 import os
 import multiprocessing as mp
 import pandas as pd


### PR DESCRIPTION
Following documentation (using Python3 / pip3 on Debian 11):

`pip3 install fhiry`

Python 3:
```
import fhiry.parallel as fp
```

Error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/dist-packages/fhiry/parallel.py", line 1, in <module>
    from src.fhiry import Fhiry, Fhirndjson
ModuleNotFoundError: No module named 'src.fhiry'```
```

This PR will fix the directory name for installations by pip package.

But since i am not familiar with your dev environment: It maybe will break paths of your dev environment, if you use(d) former dir name without errors.
