### PR TITLE
Patient id handling in fhiry.py like in fhirndjson.py

### DIFF
--- a/src/fhiry/fhirndjson.py
+++ b/src/fhiry/fhirndjson.py
@@ -75,7 +75,7 @@ class Fhirndjson(object):
                 del self._df[col]
 
     def add_patient_id(self):
-        """Create a patientId column with the resource.id of the first Patient resource
+        """Create a patientId column with the id if a Patient resource or with the subject.reference if other resource type
         """
         self._df['patientId'] = self._df.apply(lambda x: x['id'] if x['resourceType']
                                                == 'Patient' else self.check_subject_reference(x), axis=1)

--- a/src/fhiry/fhiry.py
+++ b/src/fhiry/fhiry.py
@@ -119,10 +119,16 @@ class Fhiry(object):
                 del self._df[col]
 
     def add_patient_id(self):
-        """Create a patientId column with the resource.id of the first Patient resource
+        """Create a patientId column with the resource.id if a Patient resource or with the resource.subject.reference if other resource type
         """
-        self._df['patientId'] = self._df[(
-            self._df['resource.resourceType'] == "Patient")].iloc[0]['resource.id']
+        self._df['patientId'] = self._df.apply(lambda x: x['resource.id'] if x['resource.resourceType']
+                                               == 'Patient' else self.check_subject_reference(x), axis=1)
+
+    def check_subject_reference(self, row):
+        try:
+            return row['resource.subject.reference'].replace('Patient/', '')
+        except:
+            return ""
 
     def get_info(self):
         if self._df is None:


### PR DESCRIPTION
Do Patient id handling in fhiry.py like in fhirndjson.py to be able to process FHIR bundles without (maximal and at least one) Patient resource like for example bundles of only other resource type(s) like only conditions or only procedures (which throws an exception because no Patient resource in the bundle) or bundles with multiple Patient resources.