### PR TITLE
Fix JSONDecodeError on parallel processing of test resources

### DIFF
--- a/src/fhiry/parallel.py
+++ b/src/fhiry/parallel.py
@@ -3,7 +3,8 @@ import os
 import multiprocessing as mp
 import pandas as pd
 
-def process_files(file):
+
+def process_file(file):
     f = Fhiry()
     return f.process_file(file)
 
@@ -12,34 +13,29 @@ def process_ndjson(file):
     f = Fhirndjson()
     return f.process_file(file)
 
+
 def process(folder):
-    # TODO: Fix the below error when ? folder has few files
-    # Currently falls back when it fails
-    # json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
-    try:
-        pool = mp.Pool(mp.cpu_count())
-        list_of_dataframes = pool.map(process_files, [folder + '/' + row for row in os.listdir(folder)])
-        pool.close()
-        return pd.concat(list_of_dataframes)
-    except:
-        f = Fhiry()
-        f.folder = folder
-        f.process_df()
-        return f.df
+
+    pool = mp.Pool(mp.cpu_count())
+
+    filenames = []
+    for filename in os.listdir(folder):
+        if filename.endswith(".json"):
+            filenames.append(folder + '/' + filename)
+
+    list_of_dataframes = pool.map(process_file, filenames)
+    pool.close()
+    return pd.concat(list_of_dataframes)
 
 
 def ndjson(folder):
-    # TODO: Fix the below error when ? folder has few files
-    # Currently falls back when it fails
-    # json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
-    try:
-        pool = mp.Pool(mp.cpu_count())
-        list_of_dataframes = pool.map(
-            process_ndjson, [folder + '/' + row for row in os.listdir(folder)])
-        pool.close()
-        return pd.concat(list_of_dataframes)
-    except:
-        f = Fhirndjson()
-        f.folder = folder
-        f.process_df()
-        return f.df
+    pool = mp.Pool(mp.cpu_count())
+
+    filenames = []
+    for filename in os.listdir(folder):
+        if filename.endswith(".ndjson"):
+            filenames.append(folder + '/' + filename)
+
+    list_of_dataframes = pool.map(process_ndjson, filenames)
+    pool.close()
+    return pd.concat(list_of_dataframes)


### PR DESCRIPTION
Fixed JSONDecodeError (occured in the test environment while processing of tests/resources/__init__.py which is not a json resource) by processing only file extension .json / .ndjson